### PR TITLE
mysqlnd_ms not working correctly, DB replication is broken

### DIFF
--- a/magento21-php56-varnish-memcache-storage/configs/mysqlnd_ms.json
+++ b/magento21-php56-varnish-memcache-storage/configs/mysqlnd_ms.json
@@ -3,12 +3,13 @@
     "master": {
       "master_0": {
         "host": "DB_1"
-      },
+      }
+    },
+    "slave": {
       "master_1": {
         "host": "DB_2"
       }
     },
-    "slave": {},
     "filters": {
       "roundrobin": {}
     },

--- a/magento21-php7-varnish-memcache-storage/configs/mysqlnd_ms.json
+++ b/magento21-php7-varnish-memcache-storage/configs/mysqlnd_ms.json
@@ -3,12 +3,13 @@
     "master": {
       "master_0": {
         "host": "DB_1"
-      },
+      }
+    },
+    "slave": {
       "master_1": {
         "host": "DB_2"
       }
     },
-    "slave": {},
     "filters": {
       "roundrobin": {}
     },


### PR DESCRIPTION
please consider this push.

With highly unreliable and buggy mysqlnd_ms plugin, Magento misbehaves, tries to write data at random to both MySQL nodes, even simultaneously, causing duplicate entries and replication breaks - this was both tested and observed on live setups.

As an alternative, I'd include a proxy, be it haproxy or mysqlproxy set up on Apache nodes to provide a better MySQL connection handler.