### PR TITLE
Fix for removing Scaled in nodes

### DIFF
--- a/magento21-php7-varnish-memcache-storage/manifest.jps
+++ b/magento21-php7-varnish-memcache-storage/manifest.jps
@@ -66,6 +66,7 @@
 	"onAfterScaleIn[nodeGroup:cp]": {
 		"forEach(event.response.nodes)": {
 			"cmd[bl]": [
+				"grep ${@i.intIP} /etc/varnish/default.vcl | grep -Po 'serv\\d*' | xargs -i sed -i '/{}/d' /etc/varnish/default.vcl",
 				"sed -i '/${@i.intIP}/d' /etc/varnish/default.vcl",
 				"/etc/init.d/varnish reload"
 			]


### PR DESCRIPTION
The scale in event was looking only for node IP address, there is also a line without an IP:

backend serv5 { .host = "10.100.130.68"; .port = "80"; .probe = {.url = "/varnish-probe.php"; .timeout = 1s; .interval = 5s; .window = 5; .threshold = 2; } }
backend serv4 { .host = "10.100.130.56"; .port = "80"; .probe = {.url = "/varnish-probe.php"; .timeout = 1s; .interval = 5s; .window = 5; .threshold = 2; } }
backend serv3 { .host = "10.100.130.30"; .port = "80"; .probe = {.url = "/varnish-probe.php"; .timeout = 1s; .interval = 5s; .window = 5; .threshold = 2; } }
backend serv2 { .host = "10.100.131.103"; .port = "80"; .probe = {.url = "/varnish-probe.php"; .timeout = 1s; .interval = 5s; .window = 5; .threshold = 2; } }
backend serv1 { .host = "10.100.130.36"; .port = "80"; .probe = {.url = "/varnish-probe.php"; .timeout = 1s; .interval = 5s; .window = 5; .threshold = 2; } }

sub vcl_init {
        new myclust = directors.round_robin();

myclust.add_backend(serv6);
myclust.add_backend(serv5);
myclust.add_backend(serv5);
myclust.add_backend(serv4);
myclust.add_backend(serv3);
myclust.add_backend(serv2);
myclust.add_backend(serv1);
}

Without removing the other line the varnish would not restart (serv6 is not defiend)