### PR TITLE
[Release monitoring] dependencies update

### DIFF
--- a/configs/deps.yaml
+++ b/configs/deps.yaml
@@ -1,4 +1,19 @@
 tags:
   litespeed:
+    litespeed:
+      digest: sha256:9b3f6d089b0fe0dd606715c6b5de66d1d3ad9a33502a3f428b68424d11a4c020
+      version: 5.4.9-php-7.4.9
   mariadb:
+    mariadb5:
+      digest: sha256:756014f61e0226fdfa32459c93c2aefabfae0dd47d4641cb82849cbc032cfa0f
+      version: 5.5.68
+    mariadb10:
+      digest: sha256:78227ca638d2341dd678f959edc660622bfb40cd174a7b7be08fe988c554193a
+      version: 10.3.24
+    mariadb104:
+      digest: sha256:ea2063b7a181d797143c974ad435e1f6d85a1844429bd9e4a4e1705c4d313175
+      version: 10.4.14
   nginxphp:
+    nginxphp:
+      digest: sha256:fe0cfae6ccdb9fa7f914a8f118e285d5eb89bf5a0b3f73367433dfe6de391d27
+      version: 1.18.0-php-7.4.9


### PR DESCRIPTION
This pull request includes the following changes: tags nginxphp 1.18.0-php-7.4.9, litespeed 5.4.9-php-7.4.9, mariadb10 10.3.24, mariadb104 10.4.14, mariadb5 5.5.68.
Please review them and merge if needed.